### PR TITLE
Update upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
 
     - name: Upload Test Report Artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: magics-test-report-${{ matrix.os }}-${{ matrix.compiler }}-magics-${{ env.MAGICS_SHA }}-magics-python-${{ env.MAGICS_PYTHON_SHA }}
         path: magics-test-report-${{ matrix.os }}-${{ matrix.compiler }}-magics-${{ env.MAGICS_SHA }}-magics-python-${{ env.MAGICS_PYTHON_SHA }}.tar

--- a/.github/workflows/reference.yml
+++ b/.github/workflows/reference.yml
@@ -151,7 +151,7 @@ jobs:
       run: python make_reference.py
 
     - name: Upload Reference Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: magics-test-reference-${{ matrix.os }}
         path: reference


### PR DESCRIPTION
Update upload-artifact and download-artifact actions to v4 as v3 and older are deprecated and will soon be removed. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/